### PR TITLE
Add error for invalid throttle value

### DIFF
--- a/src/DShotPIO.py
+++ b/src/DShotPIO.py
@@ -3,6 +3,10 @@ from rp2 import PIO, StateMachine, asm_pio
 
 # DShot implementation derived from: https://brushlesswhoop.com/dshot-and-bidirectional-dshot/
 
+class InvalidThrottleException(Exception):
+    def __init__(self,message):
+        self.message=message
+
 # PIO assembly code for sending DShot throttle packets
 # This is set up to transmit the 16 high order bits of a 32 bit input from high to low order
 # Each bit is sent in 8 clock cycles
@@ -32,6 +36,8 @@ class DShotPIO:
 
     # Every time this is called, one 16 bit throttel packet will be sent on the configured wire
     def sendThrottleCommand(self, throttle):    
+        if throttle<0:
+            raise InvalidThrottleException("throttle should be greater than 0")
         # Shift bits one left to set telemetry bit to 0
         throttleWithTelemetry = throttle << 1
         

--- a/src/DShotPIO.py
+++ b/src/DShotPIO.py
@@ -37,7 +37,9 @@ class DShotPIO:
     # Every time this is called, one 16 bit throttel packet will be sent on the configured wire
     def sendThrottleCommand(self, throttle):    
         if throttle<0:
-            raise InvalidThrottleException("throttle should be greater than 0")
+            raise InvalidThrottleException("Throttle should be greater than 0.")
+        if throttle>2047:
+            raise InvalidThrottleException("Throttle value is too high. Maximum value is 2047.")
         # Shift bits one left to set telemetry bit to 0
         throttleWithTelemetry = throttle << 1
         


### PR DESCRIPTION
add an exception when a throttle of less than 0 or greater than 2047 is sent to sendThrottleCommand. 

Without this change if a negative throttle is sent the value will overflow. ie if a value of -1 is sent to the sendThrottleCommand method the resulting DSHOT packet has a throttle of 2047 (max power). 

If a value greater than 2047 is sent then the value will overflow and become low. ie if 2048 is sent the resulting DSHOT packet has a value of 0 (invalid packet).

Either of these behaviors seem to be unexpected. They could cause issues as the throttle may be suddenly changed from low power to full power or full power to low power. This may cause damage to the motor.